### PR TITLE
Update trim slider from controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Display the trimmer containing video thumbnails with rotation and crop parameter
 | Widget? child | The `child` param can be specify to display a widget below this one (e.g: TrimTimeline) |
 | bool hasHaptic = true | The `hasHaptic` param specifies if haptic feed back can be triggered when the trim touch an edge (left or right) |
 | double maxViewportRatioo = 2.5 | The `maxViewportRatio` param specifies the upper limit of the view ratio |
+| ScrollController? scrollController | The `scrollController` param specifies the scroll controller to use for the trim slider view |
 
 ##### 2. TrimTimeline
 

--- a/example/lib/crop.dart
+++ b/example/lib/crop.dart
@@ -107,12 +107,10 @@ class CropScreen extends StatelessWidget {
                 flex: 2,
                 child: IconButton(
                   onPressed: () {
-                    // 2 WAYS TO UPDATE CROP
-                    // WAY 1:
-                    controller.updateCrop();
-                    // WAY 2:
-                    // controller.minCrop = controller.cacheMinCrop;
-                    // controller.maxCrop = controller.cacheMaxCrop;
+                    // WAY 1: validate crop parameters set in the crop view
+                    controller.applyCacheCrop();
+                    // WAY 2: update manually with Offset values
+                    // controller.updateCrop(const Offset(0.2, 0.2), const Offset(0.8, 0.8));
                     Navigator.pop(context);
                   },
                   icon: Center(

--- a/lib/ui/trim/trim_slider.dart
+++ b/lib/ui/trim/trim_slider.dart
@@ -22,6 +22,7 @@ class TrimSlider extends StatefulWidget {
     this.child,
     this.hasHaptic = true,
     this.maxViewportRatio = 2.5,
+    this.scrollController,
   });
 
   /// The [controller] param is mandatory so every change in the controller settings will propagate in the trim slider view
@@ -59,6 +60,9 @@ class TrimSlider extends StatefulWidget {
   ///
   /// Defaults to `2.5`
   final double maxViewportRatio;
+
+  //// The [scrollController] param specifies the scroll controller to use for the trim slider view
+  final ScrollController? scrollController;
 
   @override
   State<TrimSlider> createState() => _TrimSliderState();
@@ -102,7 +106,7 @@ class _TrimSliderState extends State<TrimSlider>
 
   // Scroll view
 
-  final _scrollController = ScrollController();
+  late final ScrollController _scrollController;
 
   /// The distance of rect left side to the left of the scroll view before bouncing
   double? _preSynchLeft;
@@ -119,6 +123,7 @@ class _TrimSliderState extends State<TrimSlider>
   @override
   void initState() {
     super.initState();
+    _scrollController = widget.scrollController ?? ScrollController();
     if (_isExtendTrim) _scrollController.addListener(attachTrimToScroll);
   }
 


### PR DESCRIPTION
Fix issue mentioned in #139, trim slider is now updated when trim values are updated programmatically.

❌ Removed setters `minTrim`, `maxTrim`, `minCrop` & `maxCrop`
✍️ Renamed `updateCrop()` into `applyCacheCrop()`
🎉New `updateCrop(double min, double max)` to update crop values programmatically.
