### PR TITLE
Support Video Url

### DIFF
--- a/example/ios/Flutter/AppFrameworkInfo.plist
+++ b/example/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>11.0</string>
+  <string>12.0</string>
 </dict>
 </plist>

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,10 +1,10 @@
 PODS:
-  - ffmpeg-kit-ios-min (5.1)
-  - ffmpeg_kit_flutter_min (5.1.0):
-    - ffmpeg_kit_flutter_min/min (= 5.1.0)
+  - ffmpeg-kit-ios-https (5.1)
+  - ffmpeg_kit_flutter_https (5.1.0):
+    - ffmpeg_kit_flutter_https/https (= 5.1.0)
     - Flutter
-  - ffmpeg_kit_flutter_min/min (5.1.0):
-    - ffmpeg-kit-ios-min (= 5.1)
+  - ffmpeg_kit_flutter_https/https (5.1.0):
+    - ffmpeg-kit-ios-https (= 5.1)
     - Flutter
   - Flutter (1.0.0)
   - image_picker_ios (0.0.1):
@@ -23,47 +23,48 @@ PODS:
     - FlutterMacOS
   - video_player_avfoundation (0.0.1):
     - Flutter
+    - FlutterMacOS
   - video_thumbnail (0.0.1):
     - Flutter
     - libwebp
 
 DEPENDENCIES:
-  - ffmpeg_kit_flutter_min (from `.symlinks/plugins/ffmpeg_kit_flutter_min/ios`)
+  - ffmpeg_kit_flutter_https (from `.symlinks/plugins/ffmpeg_kit_flutter_https/ios`)
   - Flutter (from `Flutter`)
   - image_picker_ios (from `.symlinks/plugins/image_picker_ios/ios`)
-  - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/ios`)
-  - video_player_avfoundation (from `.symlinks/plugins/video_player_avfoundation/ios`)
+  - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
+  - video_player_avfoundation (from `.symlinks/plugins/video_player_avfoundation/darwin`)
   - video_thumbnail (from `.symlinks/plugins/video_thumbnail/ios`)
 
 SPEC REPOS:
   trunk:
-    - ffmpeg-kit-ios-min
+    - ffmpeg-kit-ios-https
     - libwebp
 
 EXTERNAL SOURCES:
-  ffmpeg_kit_flutter_min:
-    :path: ".symlinks/plugins/ffmpeg_kit_flutter_min/ios"
+  ffmpeg_kit_flutter_https:
+    :path: ".symlinks/plugins/ffmpeg_kit_flutter_https/ios"
   Flutter:
     :path: Flutter
   image_picker_ios:
     :path: ".symlinks/plugins/image_picker_ios/ios"
   path_provider_foundation:
-    :path: ".symlinks/plugins/path_provider_foundation/ios"
+    :path: ".symlinks/plugins/path_provider_foundation/darwin"
   video_player_avfoundation:
-    :path: ".symlinks/plugins/video_player_avfoundation/ios"
+    :path: ".symlinks/plugins/video_player_avfoundation/darwin"
   video_thumbnail:
     :path: ".symlinks/plugins/video_thumbnail/ios"
 
 SPEC CHECKSUMS:
-  ffmpeg-kit-ios-min: 3748f7726cd539e308090371a9d572d1a9dfaf7e
-  ffmpeg_kit_flutter_min: 03876cb5ff5f7cf493cbcef07fa738ae423e009c
-  Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
-  image_picker_ios: 4a8aadfbb6dc30ad5141a2ce3832af9214a705b5
+  ffmpeg-kit-ios-https: 8dffbe1623a2f227be98fc314294847a97f818e4
+  ffmpeg_kit_flutter_https: 8783df90a81483113f7d277813309cbf544af765
+  Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
+  image_picker_ios: c560581cceedb403a6ff17f2f816d7fea1421fc1
   libwebp: 60305b2e989864154bd9be3d772730f08fc6a59c
-  path_provider_foundation: c68054786f1b4f3343858c1e1d0caaded73f0be9
-  video_player_avfoundation: 81e49bb3d9fb63dccf9fa0f6d877dc3ddbeac126
+  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
+  video_player_avfoundation: 7c6c11d8470e1675df7397027218274b6d2360b3
   video_thumbnail: c4e2a3c539e247d4de13cd545344fd2d26ffafd1
 
 PODFILE CHECKSUM: ccd901b1465efa56fa30557fdc5ae4eddcc3f504
 
-COCOAPODS: 1.11.3
+COCOAPODS: 1.15.2

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 51;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -139,6 +139,7 @@
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
 				2429AC40B28B8167C3DF858E /* [CP] Embed Pods Frameworks */,
+				C3CB5FC5648CB619D6C1CEC4 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -155,7 +156,7 @@
 		97C146E61CF9000F007C117D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1300;
+				LastUpgradeCheck = 1510;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {
@@ -238,10 +239,12 @@
 		};
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
+				"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}",
 			);
 			name = "Thin Binary";
 			outputPaths = (
@@ -252,6 +255,7 @@
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -263,6 +267,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
+		};
+		C3CB5FC5648CB619D6C1CEC4 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
+			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -339,7 +360,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;
@@ -425,7 +446,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -474,7 +495,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;

--- a/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1510"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -45,5 +45,7 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
 </dict>
 </plist>

--- a/example/lib/export_service.dart
+++ b/example/lib/export_service.dart
@@ -1,11 +1,11 @@
 import 'dart:developer';
 import 'dart:io';
 
-import 'package:ffmpeg_kit_flutter_min/ffmpeg_kit.dart';
-import 'package:ffmpeg_kit_flutter_min/ffmpeg_kit_config.dart';
-import 'package:ffmpeg_kit_flutter_min/ffmpeg_session.dart';
-import 'package:ffmpeg_kit_flutter_min/return_code.dart';
-import 'package:ffmpeg_kit_flutter_min/statistics.dart';
+import 'package:ffmpeg_kit_flutter_https/ffmpeg_kit.dart';
+import 'package:ffmpeg_kit_flutter_https/ffmpeg_kit_config.dart';
+import 'package:ffmpeg_kit_flutter_https/ffmpeg_session.dart';
+import 'package:ffmpeg_kit_flutter_https/return_code.dart';
+import 'package:ffmpeg_kit_flutter_https/statistics.dart';
 import 'package:video_editor/video_editor.dart';
 
 class ExportService {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,11 +1,11 @@
 import 'dart:io';
 
-import 'package:video_editor_example/crop_page.dart';
-import 'package:video_editor_example/export_service.dart';
-import 'package:video_editor_example/widgets/export_result.dart';
 import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:video_editor/video_editor.dart';
+import 'package:video_editor_example/crop_page.dart';
+import 'package:video_editor_example/export_service.dart';
+import 'package:video_editor_example/widgets/export_result.dart';
 
 void main() => runApp(
       MaterialApp(
@@ -42,10 +42,23 @@ class _VideoEditorExampleState extends State<VideoEditorExample> {
       Navigator.push(
         context,
         MaterialPageRoute<void>(
-          builder: (BuildContext context) => VideoEditor(file: File(file.path)),
+          builder: (BuildContext context) =>
+              VideoEditor.fromFile(file: File(file.path)),
         ),
       );
     }
+  }
+
+  void _loadVideoUrl() async {
+    Navigator.push(
+      context,
+      MaterialPageRoute<void>(
+        builder: (BuildContext context) => const VideoEditor.fromUrl(
+          url:
+              'https://flutter.github.io/assets-for-api-docs/assets/videos/butterfly.mp4',
+        ),
+      ),
+    );
   }
 
   @override
@@ -61,6 +74,10 @@ class _VideoEditorExampleState extends State<VideoEditorExample> {
               onPressed: _pickVideo,
               child: const Text("Pick Video From Gallery"),
             ),
+            ElevatedButton(
+              onPressed: _loadVideoUrl,
+              child: const Text("Load Video From Url"),
+            ),
           ],
         ),
       ),
@@ -72,9 +89,12 @@ class _VideoEditorExampleState extends State<VideoEditorExample> {
 //VIDEO EDITOR SCREEN//
 //-------------------//
 class VideoEditor extends StatefulWidget {
-  const VideoEditor({super.key, required this.file});
+  const VideoEditor.fromFile({super.key, required this.file}) : url = null;
+  const VideoEditor.fromUrl({super.key, required this.url}) : file = null;
 
-  final File file;
+  final File? file;
+
+  final String? url;
 
   @override
   State<VideoEditor> createState() => _VideoEditorState();
@@ -85,11 +105,17 @@ class _VideoEditorState extends State<VideoEditor> {
   final _isExporting = ValueNotifier<bool>(false);
   final double height = 60;
 
-  late final VideoEditorController _controller = VideoEditorController.file(
-    widget.file,
-    minDuration: const Duration(seconds: 1),
-    maxDuration: const Duration(seconds: 10),
-  );
+  late final VideoEditorController _controller = widget.file != null
+      ? VideoEditorController.file(
+          widget.file!,
+          minDuration: const Duration(seconds: 1),
+          maxDuration: const Duration(seconds: 10),
+        )
+      : VideoEditorController.url(
+          widget.url!,
+          minDuration: const Duration(seconds: 1),
+          maxDuration: const Duration(seconds: 10),
+        );
 
   @override
   void initState() {
@@ -238,12 +264,12 @@ class _VideoEditorState extends State<VideoEditor> {
                                   margin: const EdgeInsets.only(top: 10),
                                   child: Column(
                                     children: [
-                                      TabBar(
+                                      const TabBar(
                                         tabs: [
                                           Row(
                                               mainAxisAlignment:
                                                   MainAxisAlignment.center,
-                                              children: const [
+                                              children: [
                                                 Padding(
                                                     padding: EdgeInsets.all(5),
                                                     child: Icon(
@@ -253,7 +279,7 @@ class _VideoEditorState extends State<VideoEditor> {
                                           Row(
                                             mainAxisAlignment:
                                                 MainAxisAlignment.center,
-                                            children: const [
+                                            children: [
                                               Padding(
                                                   padding: EdgeInsets.all(5),
                                                   child:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,7 +1,7 @@
 name: video_editor_example
 description: The example project for the video_editor package.
 
-publish_to: "none" 
+publish_to: "none"
 version: 3.0.0+1
 
 environment:
@@ -19,7 +19,7 @@ dependencies:
   image_picker: ^0.8.9
   path: ^1.8.2
   video_player: ^2.6.1
-  ffmpeg_kit_flutter_min: ^5.1.0
+  ffmpeg_kit_flutter_https: ^5.1.0
 
 flutter:
   uses-material-design: true

--- a/lib/src/export/ffmpeg_export_config.dart
+++ b/lib/src/export/ffmpeg_export_config.dart
@@ -178,7 +178,7 @@ class VideoFFmpegVideoEditorConfig extends FFmpegVideoEditorConfig {
   /// the video applying the editing parameters.
   @override
   Future<FFmpegVideoEditorExecute> getExecuteConfig() async {
-    final String videoPath = controller.file.path;
+    final String videoPath = controller.path;
     final String outputPath =
         await getOutputPath(filePath: videoPath, format: format);
     final List<String> filters = getExportFilters();
@@ -229,7 +229,7 @@ class CoverFFmpegVideoEditorConfig extends FFmpegVideoEditorConfig {
   Future<String?> _generateCoverFile() async => VideoThumbnail.thumbnailFile(
         imageFormat: ImageFormat.JPEG,
         thumbnailPath: (await getTemporaryDirectory()).path,
-        video: controller.file.path,
+        video: controller.path,
         timeMs: controller.selectedCoverVal?.timeMs ??
             controller.startTrim.inMilliseconds,
         quality: quality,

--- a/lib/src/utils/thumbnails.dart
+++ b/lib/src/utils/thumbnails.dart
@@ -9,7 +9,7 @@ Stream<List<Uint8List>> generateTrimThumbnails(
   VideoEditorController controller, {
   required int quantity,
 }) async* {
-  final String path = controller.file.path;
+  final String path = controller.path;
   final double eachPart = controller.videoDuration.inMilliseconds / quantity;
   List<Uint8List> byteList = [];
 
@@ -45,7 +45,7 @@ Stream<List<CoverData>> generateCoverThumbnails(
   for (int i = 0; i < quantity; i++) {
     try {
       final CoverData bytes = await generateSingleCoverThumbnail(
-        controller.file.path,
+        controller.path,
         timeMs: (controller.isTrimmed
                 ? (eachPart * i) + controller.startTrim.inMilliseconds
                 : (eachPart * i))


### PR DESCRIPTION
### Description
The current implementation of VideoEditorController only accepts local File types for video input. This limitation restricts the ability to use remote video URLs directly within the video editor.

### Changes
Added remote video url support for VideoEditorController.

### Sample Demo
![Simulator Screen Recording - iPhone 15 Pro Max - 2024-08-07 at 19 59 42](https://github.com/user-attachments/assets/d960ed0d-a3e3-4f99-aa11-e97e5f040067)
