### PR TITLE
[iOS] Spaces in filepath v2

### DIFF
--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -1,8 +1,9 @@
 import 'dart:io';
+
 import 'package:flutter/material.dart';
+import 'package:video_editor/src/models/cover_data.dart';
 import 'package:video_editor/src/utils/helpers.dart';
 import 'package:video_editor/src/utils/thumbnails.dart';
-import 'package:video_editor/src/models/cover_data.dart';
 import 'package:video_editor/video_editor.dart';
 import 'package:video_player/video_player.dart';
 
@@ -52,10 +53,7 @@ class VideoEditorController extends ChangeNotifier {
     this.coverStyle = const CoverSelectionStyle(),
     this.cropStyle = const CropGridStyle(),
     TrimSliderStyle? trimStyle,
-  })  : _video = VideoPlayerController.file(File(
-          // https://github.com/flutter/flutter/issues/40429#issuecomment-549746165
-          Platform.isIOS ? Uri.encodeFull(file.path) : file.path,
-        )),
+  })  : _video = VideoPlayerController.file(file),
         trimStyle = trimStyle ?? TrimSliderStyle(),
         assert(maxDuration > minDuration,
             'The maximum duration must be bigger than the minimum duration');


### PR DESCRIPTION
This PR reverts changes made in the past. In the past, to load a path on ios (with spaces), it must have been first encoded in order to work. That was the reason why I made [this](https://github.com/LeGoffMael/video_editor/pull/108) PR in the first place.

However in some newer versions of Flutter (tested on 3.24.5 and `video_player` 2.9.2), `VideoPlayerController` now expect the standard path, and if encoded it breaks. (I haven't tried to find the exact version, which changed it)

Fixes: https://github.com/LeGoffMael/video_editor/issues/172