### PR TITLE
Add videoOptions parameter to VideoPlayerController

### DIFF
--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -39,7 +39,7 @@ class VideoEditorController extends ChangeNotifier {
 
   /// Video from [File].
   final File file;
-
+  final VideoPlayerOptions? videoPlayerOptions;
   /// Constructs a [VideoEditorController] that edits a video from a file.
   ///
   /// The [file] argument must not be null.
@@ -51,13 +51,14 @@ class VideoEditorController extends ChangeNotifier {
     this.trimThumbnailsQuality = 10,
     this.coverStyle = const CoverSelectionStyle(),
     this.cropStyle = const CropGridStyle(),
+    this.videoPlayerOptions,
     TrimSliderStyle? trimStyle,
   })  : _video = VideoPlayerController.file(
             File(
               // https://github.com/flutter/flutter/issues/40429#issuecomment-549746165
               Platform.isIOS ? Uri.encodeFull(file.path) : file.path,
             ),
-            videoPlayerOptions: VideoPlayerOptions(mixWithOthers: true)),
+            videoPlayerOptions:videoPlayerOptions ),
         trimStyle = trimStyle ?? TrimSliderStyle(),
         assert(maxDuration > minDuration,
             'The maximum duration must be bigger than the minimum duration');

--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -52,10 +52,12 @@ class VideoEditorController extends ChangeNotifier {
     this.coverStyle = const CoverSelectionStyle(),
     this.cropStyle = const CropGridStyle(),
     TrimSliderStyle? trimStyle,
-  })  : _video = VideoPlayerController.file(File(
-          // https://github.com/flutter/flutter/issues/40429#issuecomment-549746165
-          Platform.isIOS ? Uri.encodeFull(file.path) : file.path,
-        )),
+  })  : _video = VideoPlayerController.file(
+            File(
+              // https://github.com/flutter/flutter/issues/40429#issuecomment-549746165
+              Platform.isIOS ? Uri.encodeFull(file.path) : file.path,
+            ),
+            videoPlayerOptions: VideoPlayerOptions(mixWithOthers: true)),
         trimStyle = trimStyle ?? TrimSliderStyle(),
         assert(maxDuration > minDuration,
             'The maximum duration must be bigger than the minimum duration');


### PR DESCRIPTION
This PR adds a videoOptions parameter to the VideoPlayerController, enabling developers to configure video playback settings directly within the controller. 